### PR TITLE
Always start playing if the current album is not playing

### DIFF
--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -34,7 +34,7 @@ export default function PlayButton({
             imageUrl,
           });
 
-          setIsPlaying(!isPlaying);
+          setIsPlaying(true);
         }
       }}
     >


### PR DESCRIPTION
currently if there is another album playing, clicking play on this album pauses the playing album and you need to click again to start playing this album.
